### PR TITLE
Extended GFX support to multiple libraries

### DIFF
--- a/src/TetrisMatrixDraw.cpp
+++ b/src/TetrisMatrixDraw.cpp
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 #include "TetrisNumbers.h"
 #include "TetrisLetters.h"
 
-TetrisMatrixDraw::TetrisMatrixDraw(Adafruit_GFX &display)	{
+TetrisMatrixDraw::TetrisMatrixDraw(Tetris_GFX &display)	{
     this->display = &display;
     resetNumStates();
 }
@@ -203,7 +203,7 @@ void TetrisMatrixDraw::drawShape(int blocktype, uint16_t color, int x_pos, int y
     }
   }
 
-   // Corner-Shape 
+   // Corner-Shape
    if (blocktype == 7)
    {
      if (num_rot == 0)
@@ -429,7 +429,7 @@ void TetrisMatrixDraw::drawLargerShape(int scale, int blocktype, uint16_t color,
     //}
   }
 
-   // Corner-Shape 
+   // Corner-Shape
    if (blocktype == 7)
    {
      if (num_rot == 0)
@@ -590,17 +590,17 @@ bool TetrisMatrixDraw::drawText(int x, int yFinish)
           }
         }
         if(this->scale <= 1){
-          drawShape(current_fall.blocktype, 
+          drawShape(current_fall.blocktype,
                     this->tetrisColors[current_fall.color],
-                    x + current_fall.x_pos + numstates[numpos].x_shift, 
-                    y + numstates[numpos].fallindex - scaledYOffset, 
+                    x + current_fall.x_pos + numstates[numpos].x_shift,
+                    y + numstates[numpos].fallindex - scaledYOffset,
                     rotations);
         } else {
-          drawLargerShape(this->scale, 
-                          current_fall.blocktype, 
-                          this->tetrisColors[current_fall.color], 
-                          x + (current_fall.x_pos * this->scale) + numstates[numpos].x_shift, 
-                          y + (numstates[numpos].fallindex * scaledYOffset) - scaledYOffset, 
+          drawLargerShape(this->scale,
+                          current_fall.blocktype,
+                          this->tetrisColors[current_fall.color],
+                          x + (current_fall.x_pos * this->scale) + numstates[numpos].x_shift,
+                          y + (numstates[numpos].fallindex * scaledYOffset) - scaledYOffset,
                           rotations);
         }
         //drawShape(current_fall.blocktype, this->tetrisColors[current_fall.color], x + current_fall.x_pos + numstates[numpos].x_shift, y + numstates[numpos].fallindex - 1, rotations);
@@ -620,24 +620,24 @@ bool TetrisMatrixDraw::drawText(int x, int yFinish)
         {
           fall_instr_let fallen_block = getFallinstrByAscii(numstates[numpos].num_to_draw, i);
           if(this->scale <= 1){
-            drawShape(fallen_block.blocktype, 
-                      this->tetrisColors[fallen_block.color], 
-                      x + fallen_block.x_pos + numstates[numpos].x_shift, 
-                      y + fallen_block.y_stop - 1, 
+            drawShape(fallen_block.blocktype,
+                      this->tetrisColors[fallen_block.color],
+                      x + fallen_block.x_pos + numstates[numpos].x_shift,
+                      y + fallen_block.y_stop - 1,
                       fallen_block.num_rot);
           } else {
-            drawLargerShape(this->scale, 
-                            fallen_block.blocktype, 
-                            this->tetrisColors[fallen_block.color], 
-                            x + (fallen_block.x_pos * this->scale) + numstates[numpos].x_shift, 
-                            y + (fallen_block.y_stop * scaledYOffset) - scaledYOffset, 
+            drawLargerShape(this->scale,
+                            fallen_block.blocktype,
+                            this->tetrisColors[fallen_block.color],
+                            x + (fallen_block.x_pos * this->scale) + numstates[numpos].x_shift,
+                            y + (fallen_block.y_stop * scaledYOffset) - scaledYOffset,
                             fallen_block.num_rot);
           }
           //drawShape(fallen_block.blocktype, this->tetrisColors[fallen_block.color], x + fallen_block.x_pos + numstates[numpos].x_shift, y + fallen_block.y_stop - 1, fallen_block.num_rot);
         }
       }
     }
-    
+
   }
 
   return finishedAnimating;
@@ -653,7 +653,7 @@ bool TetrisMatrixDraw::drawNumbers(int x, int yFinish, bool displayColon)
 
   for (int numpos = 0; numpos < this->sizeOfValue; numpos++)
   {
-    if(numstates[numpos].num_to_draw >= 0) 
+    if(numstates[numpos].num_to_draw >= 0)
     {
       // Draw falling shape
       if (numstates[numpos].blockindex < blocksPerNumber[numstates[numpos].num_to_draw])
@@ -698,17 +698,17 @@ bool TetrisMatrixDraw::drawNumbers(int x, int yFinish, bool displayColon)
         }
 
         if(this->scale <= 1){
-          drawShape(current_fall.blocktype, 
+          drawShape(current_fall.blocktype,
                     this->tetrisColors[current_fall.color],
-                    x + current_fall.x_pos + numstates[numpos].x_shift, 
-                    y + numstates[numpos].fallindex - scaledYOffset, 
+                    x + current_fall.x_pos + numstates[numpos].x_shift,
+                    y + numstates[numpos].fallindex - scaledYOffset,
                     rotations);
         } else {
-          drawLargerShape(this->scale, 
-                          current_fall.blocktype, 
-                          this->tetrisColors[current_fall.color], 
-                          x + (current_fall.x_pos * this->scale) + numstates[numpos].x_shift, 
-                          y + (numstates[numpos].fallindex * scaledYOffset) - scaledYOffset, 
+          drawLargerShape(this->scale,
+                          current_fall.blocktype,
+                          this->tetrisColors[current_fall.color],
+                          x + (current_fall.x_pos * this->scale) + numstates[numpos].x_shift,
+                          y + (numstates[numpos].fallindex * scaledYOffset) - scaledYOffset,
                           rotations);
         }
         numstates[numpos].fallindex++;
@@ -727,17 +727,17 @@ bool TetrisMatrixDraw::drawNumbers(int x, int yFinish, bool displayColon)
         {
           fall_instr fallen_block = getFallinstrByNum(numstates[numpos].num_to_draw, i);
           if(this->scale <= 1){
-            drawShape(fallen_block.blocktype, 
-                      this->tetrisColors[fallen_block.color], 
-                      x + fallen_block.x_pos + numstates[numpos].x_shift, 
-                      y + fallen_block.y_stop - 1, 
+            drawShape(fallen_block.blocktype,
+                      this->tetrisColors[fallen_block.color],
+                      x + fallen_block.x_pos + numstates[numpos].x_shift,
+                      y + fallen_block.y_stop - 1,
                       fallen_block.num_rot);
           } else {
-            drawLargerShape(this->scale, 
-                            fallen_block.blocktype, 
-                            this->tetrisColors[fallen_block.color], 
-                            x + (fallen_block.x_pos * this->scale) + numstates[numpos].x_shift, 
-                            y + (fallen_block.y_stop * scaledYOffset) - scaledYOffset, 
+            drawLargerShape(this->scale,
+                            fallen_block.blocktype,
+                            this->tetrisColors[fallen_block.color],
+                            x + (fallen_block.x_pos * this->scale) + numstates[numpos].x_shift,
+                            y + (fallen_block.y_stop * scaledYOffset) - scaledYOffset,
                             fallen_block.num_rot);
           }
         }
@@ -755,7 +755,7 @@ bool TetrisMatrixDraw::drawNumbers(int x, int yFinish, bool displayColon)
 
 void TetrisMatrixDraw::drawColon(int x, int y, uint16_t colonColour){
   int colonSize = 2 * this->scale;
-  int xColonPos = x + (TETRIS_DISTANCE_BETWEEN_DIGITS * 2 * this->scale);  
+  int xColonPos = x + (TETRIS_DISTANCE_BETWEEN_DIGITS * 2 * this->scale);
   display->fillRect(xColonPos, y + (12 * this->scale), colonSize, colonSize, colonColour);
   display->fillRect(xColonPos, y + (8 * this->scale), colonSize, colonSize, colonColour);
 }

--- a/src/TetrisMatrixDraw.h
+++ b/src/TetrisMatrixDraw.h
@@ -21,7 +21,32 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 #define TetrisMatrixDraw_h
 
 #include <Arduino.h>
-#include "Adafruit_GFX.h"
+
+#if __has_include(<TFT_eSPI.h>) // pros: wide support, cons: needs a setup
+  #include <TFT_eSPI.h> // https://github.com/Bodmer/TFT_eSPI
+  #define Tetris_GFX TFT_eSprite
+
+#elif __has_include(<LovyanGFX.h>) // pros: has autodetect, cons: no AVR support
+  #define LGFX_AUTODETECT
+  #define LGFX_USE_V1
+  #include <LovyanGFX.h> // https://github.com/lovyan03/LovyanGFX
+  #define Tetris_GFX LGFX_Sprite
+
+#elif __has_include(<M5GFX.h>) // pros: handles every M5Stack devices, cons: no AVR support
+  #include <M5GFX.h> // https://github.com/m5stack/M5GFX
+  #define Tetris_GFX LGFX_Sprite
+
+#elif __has_include(<Arduino_GFX.h>) // pros: very customizable
+  #include <Arduino_GFX.h> // https://github.com/moononournation/Arduino_GFX
+  #define Tetris_GFX Arduino_Canvas
+
+#else
+  // pros: very educational, cons: has many library dependencies
+  #include <Adafruit_GFX.h> // https://github.com/adafruit/Adafruit_GFX
+  #define Tetris_GFX Adafruit_GFX
+
+#endif
+
 
 #define TETRIS_MAX_NUMBERS 9
 
@@ -45,8 +70,8 @@ typedef struct
 class TetrisMatrixDraw
 {
     public:
-        TetrisMatrixDraw (Adafruit_GFX  &display);
-        Adafruit_GFX  *display;
+        TetrisMatrixDraw (Tetris_GFX &display);
+        Tetris_GFX  *display;
         bool drawNumbers(int x = 0, int y = 0, bool displayColon = false);
         bool drawText(int x = 0, int y = 0);
         void drawChar(String letter, uint8_t x, uint8_t y, uint16_t color);


### PR DESCRIPTION
hey thanks for the awesome library :+1: 

This PR introduces the possibility to attach additional LCD libraries as shims:
  - TFT_eSPI
  - Arduino_GFX
  - M5GFX
  - LovyanGFX

This does not appear to break the existing examples. 

Usage is quite trivial: just include the chosen LCD library from your sketch before including TetrisMatrixDraw.h.

If you're interested by this PR I can add a couple of examples.

@witnessmenow I've also applied the same changes to the `drop_default_Fix` branch on my fork, just in case :wink: 

