### PR TITLE
Limit library architecture and CI build to ESP32.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -33,17 +33,10 @@ jobs:
 
       matrix:
         board:
-          - fqbn: arduino:avr:uno
-            platforms: |
-              - name: arduino:avr
           - fqbn: esp32:esp32:esp32
             platforms: |
               - name: esp32:esp32
                 source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-          - fqbn: esp8266:esp8266:huzzah
-            platforms: |
-              - name: esp8266:esp8266
-                source-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
 
     steps:
       - name: Checkout

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -54,7 +54,7 @@ jobs:
         run: pip3 install pyserial
 
       - name: Compile examples
-        uses: arduino/compile-sketches@main
+        uses: arduino/compile-sketches@v1
         with:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -26,60 +26,17 @@ jobs:
 
       matrix:
         board:
-#           - fqbn: arduino:samd:mkr1000
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrzero
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrwifi1010
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrfox1200
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrwan1300
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrwan1310
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrgsm1400
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrnb1500
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:samd:mkrvidor4000
-#             platforms: |
-#               - name: arduino:samd
-#           - fqbn: arduino:mbed_portenta:envie_m7
-#             platforms: |
-#               - name: arduino:mbed_portenta
-#           - fqbn: arduino:mbed_portenta:envie_m4
-#             platforms: |
-#               - name: arduino:mbed_portenta
-#           - fqbn: arduino:mbed_nano:nano33ble
-#             platforms: |
-#               - name: arduino:mbed_nano
-#           - fqbn: arduino:mbed_nano:nanorp2040connect
-#             platforms: |
-#               - name: arduino:mbed_nano
-#           - fqbn: arduino:mbed_edge:edge_control
-#             platforms: |
-#               - name: arduino:mbed_edge
+          - fqbn: arduino:avr:uno
+            platforms: |
+              - name: arduino:avr
           - fqbn: esp32:esp32:esp32
             platforms: |
               - name: esp32:esp32
                 source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-#           - fqbn: esp8266:esp8266:huzzah
-#             platforms: |
-#               - name: esp8266:esp8266
-#                 source-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
-#           - fqbn: rp2040:rp2040:rpipico
-#             platforms: |
-#               - name: rp2040:rp2040
-#                 source-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+           - fqbn: esp8266:esp8266:huzzah
+             platforms: |
+               - name: esp8266:esp8266
+                 source-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
 
     steps:
       - name: Checkout

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@v1
         with:
+          cli-compile-flags: |
+            - --warnings
+            - default
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}
           libraries: ${{ env.LIBRARIES }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}
+          libraries: ${{ env.LIBRARIES }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -20,6 +20,13 @@ jobs:
 
     env:
       SKETCHES_REPORTS_PATH: sketches-reports
+      LIBRARIES: |
+        # Install the library from the local path.
+        - source-path: ./
+        - name: Adafruit GFX Library
+        - name: PxMatrix LED MATRIX library
+        - name: Time
+        - name: NtpClientLib
 
     strategy:
       fail-fast: false
@@ -53,12 +60,6 @@ jobs:
           platforms: ${{ matrix.board.platforms }}
           enable-deltas-report: true
           sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
-          libraries: |
-            - name: Adafruit GFX Library
-            - name: PxMatrix LED MATRIX library
-            - name: Time
-            - name: NtpClientLib
-            - source-path: ./src
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -40,10 +40,10 @@ jobs:
             platforms: |
               - name: esp32:esp32
                 source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-           - fqbn: esp8266:esp8266:huzzah
-             platforms: |
-               - name: esp8266:esp8266
-                 source-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+          - fqbn: esp8266:esp8266:huzzah
+            platforms: |
+              - name: esp8266:esp8266
+                source-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
 
     steps:
       - name: Checkout

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Library for drawing text out with tetris blocks
 paragraph=Uses the Adafruit GFX library to draw tetris blocks into letters on displays.
 category=Display
 url=https://github.com/toblum/TetrisAnimation
-architectures=avr,esp8266,esp32
+architectures=esp32
 depends=Adafruit GFX Library,PxMatrix LED MATRIX library


### PR DESCRIPTION
Hi @toblum :coffee: :wave:

Jointly @per1234 and I have fixed your CI.

Right now your library only seems to support ESP32 (and that's allright), so I've limited the supported architectures to esp32. Good for you?

All the best, Alex